### PR TITLE
small fix for libpcre wasm build file

### DIFF
--- a/build_for_crystal.sh
+++ b/build_for_crystal.sh
@@ -7,7 +7,7 @@ export AR="$WASI_SDK_PATH/bin/llvm-ar"
 export RANLIB="$WASI_SDK_PATH/bin/llvm-ranlib"
 export LD="$WASI_SDK_PATH/bin/wasm-ld"
 
-target=$1
+target=${1:-default}
 
 if [ -z "$target" ]; then
   echo "You must specify a target (wasm32-wasi or wasm32-emscripten)"


### PR DESCRIPTION
set -u will abort exactly if you reference a variable that has not been set. `target` is being invoked with no arguments, causing `$1` to be unset. Using a default expansion will solve this issue. 